### PR TITLE
ci: Pass base image name to build workflows

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -31,9 +31,9 @@ jobs:
         with:
           node-version: "lts/*"
 
-      - name: Install Dev Container CLI
+      - name: Install Dev Container CLI and strip-json-comments-cli
         run: |
-          npm install -g @devcontainers/cli
+          npm install -g @devcontainers/cli strip-json-comments-cli
 
       - name: Build and Push Variant
         run: |
@@ -49,6 +49,7 @@ jobs:
               --cache-to "type=registry,ref=ghcr.io/${REPO_NAME}/cache:${VARIANT}-${BRANCH_DATE_TAG},mode=max" \
               --cache-from "type=registry,ref=ghcr.io/${REPO_NAME}/cache:${VARIANT}-${BRANCH_DATE_TAG}" \
               --cache-from "type=registry,ref=ghcr.io/${REPO_NAME}/cache:${VARIANT}-latest" \
+              --base-tag-suffix "${BRANCH_DATE_TAG}" \
               --user "${GITHUB_ACTOR}" \
               -- \
               ${VARIANT}
@@ -61,6 +62,7 @@ jobs:
                   --cache-to "type=registry,ref=ghcr.io/${REPO_NAME}/cache:${VARIANT}-latest,mode=max" \
                   --cache-from "type=registry,ref=ghcr.io/${REPO_NAME}/cache:${VARIANT}-${BRANCH_DATE_TAG}" \
                   --cache-from "type=registry,ref=ghcr.io/${REPO_NAME}/cache:${VARIANT}-latest" \
+                  --base-tag-suffix "${BRANCH_DATE_TAG}" \
                   --user "${GITHUB_ACTOR}" \
                   -- \
                   ${VARIANT}

--- a/scripts/image_set_build_args.sh
+++ b/scripts/image_set_build_args.sh
@@ -4,5 +4,5 @@ set -u
 set -o pipefail
 
 strip-json-comments <"${1}" |
-    jq --arg baseRepo "${2}" --arg baseTagSuffix "${3}" \
+    jq -r --arg baseRepo "${2}" --arg baseTagSuffix "${3}" \
         '.build.args.BASE_REPO = $baseRepo | .build.args.BASE_TAG_SUFFIX = $baseTagSuffix'

--- a/scripts/image_set_build_args.sh
+++ b/scripts/image_set_build_args.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+set -u
+set -o pipefail
+
+strip-json-comments <"${1}" |
+    jq --arg baseRepo "${2}" --arg baseTagSuffix "${3}" \
+        '.build.args.BASE_REPO = $baseRepo | .build.args.BASE_TAG_SUFFIX = $baseTagSuffix'

--- a/src/dind/.devcontainer/Dockerfile
+++ b/src/dind/.devcontainer/Dockerfile
@@ -1,1 +1,3 @@
-FROM ghcr.io/hankei6km/test-dev-containers-images:basic-latest
+ARG BASE_REPO="ghcr.io/hankei6km/test-dev-containers-images"
+ARG BASE_TAG_SUFFIX="latest"
+FROM ${BASE_REPO}:basic-${BASE_TAG_SUFFIX}

--- a/src/dind/.devcontainer/devcontainer.json
+++ b/src/dind/.devcontainer/devcontainer.json
@@ -1,7 +1,11 @@
 {
   "build": {
     "dockerfile": "./Dockerfile",
-    "context": "."
+    "context": ".",
+    "args": {
+      "BASE_REPO": "ghcr.io/hankei6km/test-dev-containers-images",
+      "BASE_TAG_SUFFIX": "latest"
+    }
   },
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {

--- a/src/node/.devcontainer/Dockerfile
+++ b/src/node/.devcontainer/Dockerfile
@@ -1,1 +1,3 @@
-FROM ghcr.io/hankei6km/test-dev-containers-images:basic-latest
+ARG BASE_REPO="ghcr.io/hankei6km/test-dev-containers-images"
+ARG BASE_TAG_SUFFIX="latest"
+FROM ${BASE_REPO}:basic-${BASE_TAG_SUFFIX}

--- a/src/node/.devcontainer/devcontainer.json
+++ b/src/node/.devcontainer/devcontainer.json
@@ -1,7 +1,11 @@
 {
   "build": {
     "dockerfile": "./Dockerfile",
-    "context": "."
+    "context": ".",
+    "args": {
+      "BASE_REPO": "ghcr.io/hankei6km/test-dev-containers-images",
+      "BASE_TAG_SUFFIX": "latest"
+    }
   },
   "features": {
     "ghcr.io/devcontainers/features/node:1": {}

--- a/src/typescript-node/.devcontainer/Dockerfile
+++ b/src/typescript-node/.devcontainer/Dockerfile
@@ -1,6 +1,8 @@
 # この Dev Container は、node variant をベースにしている。
 # 他の variant とは異なるので注意(node variant の後にビルドすること)
-FROM ghcr.io/hankei6km/test-dev-containers-images:node-latest
+ARG BASE_REPO="ghcr.io/hankei6km/test-dev-containers-images"
+ARG BASE_TAG_SUFFIX="latest"
+FROM ${BASE_REPO}:node-${BASE_TAG_SUFFIX}
 
 # Install tslint, typescript. eslint is installed by node-latest variant.
 # https://github.com/devcontainers/images/blob/a5fe28bee4dd323acc53d2d3702e6f2ca00d4182/src/typescript-node/.devcontainer/Dockerfile#L4-L7

--- a/src/typescript-node/.devcontainer/devcontainer.json
+++ b/src/typescript-node/.devcontainer/devcontainer.json
@@ -1,7 +1,11 @@
 {
   "build": {
     "dockerfile": "./Dockerfile",
-    "context": "."
+    "context": ".",
+    "args": {
+      "BASE_REPO": "ghcr.io/hankei6km/test-dev-containers-images",
+      "BASE_TAG_SUFFIX": "latest"
+    }
   },
   "remoteUser": "devcontainer",
   "customizations": {


### PR DESCRIPTION
ワークフローでVariantsをビルドするとき、極力新しいベース(basic)イメージを使うための変更。
- Dockerfile の FROM を ARG から組み立てる
- devcontainer.json の buildArgs に、イメージ(REPO)とタグの末尾を設定(devcontainer build では arg を指定できないため)
- image_build.sh の引数を追加(タグの末尾を指定)
- ワークフローではブランチ内(トリガー)で作成した basic イメージを使うように変更
