### PR TITLE
ci: Add devcontainer lock file

### DIFF
--- a/src/dind/.devcontainer/devcontainer-lock.json
+++ b/src/dind/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.12.2",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:842d2ed40827dc91b95ef727771e170b0e52272404f00dba063cee94eafac4bb",
+      "integrity": "sha256:842d2ed40827dc91b95ef727771e170b0e52272404f00dba063cee94eafac4bb"
+    }
+  }
+}


### PR DESCRIPTION
- 存在しない場合、dependabotでは追加しないもよう(たぶん)
- typescript-node は features を設定しないのでロックファイルを作成できない
    - devcontainer upgrade ではエラーになった
    - dependabot のログではとくにエラーになっていなさそう(指定から外す？)
